### PR TITLE
Video stream stays on when MM is shut down

### DIFF
--- a/tools/facerecognition.py
+++ b/tools/facerecognition.py
@@ -2,8 +2,7 @@
 # python pi_face_recognition.py --cascade haarcascade_frontalface_default.xml --encodings encodings.pickle
 
 # import the necessary packages
-from stream import VideoStream
-from imutils.video import FPS
+from imutils.video import FPS, VideoStream
 from datetime import datetime
 import face_recognition
 import argparse


### PR DESCRIPTION
Importing VideoStream from imutils fixes the bug. However, it started to give 'FATAL: exception not rethrown'. Also, 'vs.stop()' is enough to shut is down the video stream (no need an if condition as suggested in the discussion.)