### PR TITLE
Stringify stderr output to avoid JSON parsing errors

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -18,6 +18,7 @@ module.exports = NodeHelper.create({
     const extendedDataset = this.config.extendDataset ? 'True' : 'False';
     const options = {
       mode: 'json',
+      stderrParser: (line) => JSON.stringify(line),
       args: [
         '--cascade=' + this.config.cascade,
         '--encodings=' + this.config.encodings,


### PR DESCRIPTION
First, thanks for this module, I recently started to play with it and felt like I could contribute :)

As mentioned in [this pyshell issue](https://github.com/extrabacon/python-shell/issues/40), when using `{mode: 'json'}`, a JSON parsing error is thrown instead of being returned through the callback, such as `SyntaxError: Unexpected token T in JSON at position 0`.
A workaround for this is to stringify the stderr output to correctly retrieve the python error.