### PR TITLE
Updated not working 'stranger' for 'unknown'

### DIFF
--- a/MMM-Face-Reco-DNN.js
+++ b/MMM-Face-Reco-DNN.js
@@ -92,8 +92,8 @@ Module.register("MMM-Face-Reco-DNN", {
 
 		if (this.config.welcomeMessage) {
 			var person = name;
-			// We get Unknown from Face-Reco and then it should be translated to stranger
-			if (person === 'Unknown') {
+			// We get unknown from Face-Reco and then it should be translated to stranger
+			if (person === 'unknown') {
 				person = this.translate('stranger');
 			}
 


### PR DESCRIPTION
Changed `if (person === 'Unknown')` to `if (person === 'unknown')` in order to function properly because **Face-Reco** gives it in _lower case_.
Before it always sayd **"Hello Unknown, nice to meet you!"** in the welcome message (and its translations) for strangers.