### PR TITLE
Add Makefile/Dockerfile to build encodings.pickle in a container

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ python3 encode.py
 
 After that you are ready to configure the module and use it on your MagicMirror.
 
+### Building encodings.pickle in a Container
+
+Another option for building the encodings.pickle file is to use a Docker container. This way all dependencies and libraries are isolated from the host OS, you will only need `make` and `docker`.
+
+```sh
+cd tools;
+make  # generate an encodings.pickle with hog, or alternatively
+
+make encoding=cnn  # overide the default to use cnn encoding
+```
+
 ### Module Usage
 
 To setup the module in MagicMirror², add the following section to the `config.js` file in the `MagicMirror/config` directory.

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,20 @@
+FROM jjanzic/docker-python3-opencv
+
+RUN pip install dlib face_recognition imutils
+
+WORKDIR /srv
+
+# Setup our user
+ARG UNAME=ocvuser
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/sh $UNAME
+
+ENV method=hog
+USER $UNAME
+
+# Add the application
+ADD *.py *.xml /srv/
+
+CMD [ "python3", "/srv/encode.py", "-i", "/srv/dataset", "-e", "/srv/model/encodings.pickle", "-d", "${method}" ]

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,9 @@
+all: image data
+
+method ?= hog
+
+image:
+	docker build --build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g) -t mmm-face-reco-dnn-dataset-runner .
+
+data:
+	docker run -it -v $(shell pwd)/../dataset:/srv/dataset -v $(shell pwd):/srv/model -e method=$(method) mmm-face-reco-dnn-dataset-runner:latest


### PR DESCRIPTION
This PR add support for building the encodings.pickle file in a Docker container. This way you can easily build the encoded dataset on another system without affected the underlying OS.