### PR TITLE
Select face name based on smallest distance

### DIFF
--- a/MMM-Face-Reco-DNN.js
+++ b/MMM-Face-Reco-DNN.js
@@ -45,6 +45,8 @@ Module.register('MMM-Face-Reco-DNN', {
     extendDataset: false,
     // if extenDataset is set, you need to set the full path of the dataset
     dataset: 'modules/MMM-Face-Reco-DNN/dataset/',
+    // How much distance between faces to consider it a match. Lower is more strict.
+    tolerance: 0.6
   },
 
   timouts: {},

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This module works in the background, and so no screenshots are available.
 - [dlib](#dlib)
 - [face_recognition](#fr)
 - [imutils](#imutils)
+- [numpy](#numpy)
 - Camera
 
 I used a [Raspberry Pi Spy Cam](https://www.digitec.ch/de/s1/product/sertronics-rpi-spycam-kamera-elektronikmodul-8194042) which i built into my [mirror](https://forum.magicmirror.builders/topic/10567/my-old-wood-mirror?page=1). It also works fine with the regular Raspberry Pi camera module.
@@ -68,6 +69,14 @@ You can install imutils over pip.
 
 ```sh
 pip install imutils
+```
+
+### <a name="numpy"></a>numpy
+
+You can install numpy over pip.
+
+```sh
+pip install numpy
 ```
 
 ## Compatibility
@@ -204,7 +213,9 @@ To setup the module in MagicMirror², add the following section to the `config.j
       // So you can extend your dataset and retrain it afterwards for better recognitions
       extendDataset: false,
       // If extendDataset is true, you need to set the full path of the dataset
-      dataset: 'modules/MMM-Face-Reco-DNN/dataset/'
+      dataset: 'modules/MMM-Face-Reco-DNN/dataset/',
+      // How much distance between faces to consider it a match. Lower is more strict.
+      tolerance: 0.6
     }
 }
 ```

--- a/node_helper.js
+++ b/node_helper.js
@@ -31,6 +31,7 @@ module.exports = NodeHelper.create({
         '--output=' + this.config.output,
         '--extendDataset=' + extendedDataset,
         '--dataset=' + this.config.dataset,
+        '--tolerance=' + this.config.tolerance
       ],
     };
 

--- a/tools/facerecognition.py
+++ b/tools/facerecognition.py
@@ -155,7 +155,8 @@ while True:
 		cv2.rectangle(frame, (left, top), (right, bottom),
 			(0, 255, 0), 2)
 		y = top - 15 if top - 15 > 15 else top + 15
-		cv2.putText(frame, name, (left, y), cv2.FONT_HERSHEY_SIMPLEX,
+		txt = name + " (" + "{:.2f}".format(minDistance) + ")"
+		cv2.putText(frame, txt, (left, y), cv2.FONT_HERSHEY_SIMPLEX,
 			0.75, (0, 255, 0), 2)
 
 	# display the image to our screen

--- a/tools/facerecognition.py
+++ b/tools/facerecognition.py
@@ -14,6 +14,7 @@ import json
 import sys
 import signal
 import os
+import numpy as np
 
 # To properly pass JSON.stringify()ed bool command line parameters, e.g. "--extendDataset"
 # See: https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
@@ -62,6 +63,8 @@ ap.add_argument("-eds", "--extendDataset", type=str2bool, required=False, defaul
 	help="Extend Dataset with unknown pictures")
 ap.add_argument("-ds", "--dataset", required=False, default="../dataset/",
 	help="path to input directory of faces + images")
+ap.add_argument("-t", "--tolerance", required=False, default=0.6,
+	help="How much distance between faces to consider it a match. Lower is more strict.")
 args = vars(ap.parse_args())
 
 # load the known faces and embeddings along with OpenCV's Haar
@@ -127,33 +130,21 @@ while True:
 	# compute the facial embeddings for each face bounding box
 	encodings = face_recognition.face_encodings(rgb, boxes)
 	names = []
+	minDistance = 0.0
 
 	# loop over the facial embeddings
 	for encoding in encodings:
-		# attempt to match each face in the input image to our known
-		# encodings
-		matches = face_recognition.compare_faces(data["encodings"],
-			encoding)
-		name = "unknown"
+		# compute distances between this encoding and the faces in dataset
+		distances = face_recognition.face_distance(data["encodings"], encoding)
 
-		# check to see if we have found a match
-		if True in matches:
-			# find the indexes of all matched faces then initialize a
-			# dictionary to count the total number of times each face
-			# was matched
-			matchedIdxs = [i for (i, b) in enumerate(matches) if b]
-			counts = {}
-
-			# loop over the matched indexes and maintain a count for
-			# each recognized face face
-			for i in matchedIdxs:
-				name = data["names"][i]
-				counts[name] = counts.get(name, 0) + 1
-
-			# determine the recognized face with the largest number
-			# of votes (note: in the event of an unlikely tie Python
-			# will select first entry in the dictionary)
-			name = max(counts, key=counts.get)
+		# the smallest distance is the closest to the encoding
+		minDistance = min(distances)
+		# save the name if the distance is below the tolerance
+		if minDistance < args["tolerance"]:
+			idx = np.where(distances == minDistance)[0][0]
+			name = data["names"][idx]
+		else:
+			name = "unknown"
 
 		# update the list of names
 		names.append(name)


### PR DESCRIPTION
This is a proposition to improve the name selection method.

The current method to find face matches is based on [this method](https://face-recognition.readthedocs.io/en/latest/face_recognition.html#face_recognition.api.compare_faces), that returns an array of boolean values. The associated name is retrieved for each `true` value ; then, the name with the highest match count is picked. 

This approach tends to favor names with more encodings in the dataset, as they are more prone to match an encoding. For instance, let's say we have two names in the dataset, Alice and Bob, respectively with 100 and 10 face encodings, that are siblings, so quite look-alike. If Bob is in front of the mirror, he might have 10 matches (100% of his encodings), but Alice might also match for 20 encodings (20% of her encodings). Even though she is less "recognized", Alice will be picked.

To avoid this behavior, this PR base the name detection on the [smallest distance](https://face-recognition.readthedocs.io/en/latest/face_recognition.html#face_recognition.api.face_distance): the chosen name is no longer the one with the more matches, but the one that has the closest encoding. It is both more reliable and more efficient, as there is less computation to make.

As a bonus, it also adds the `tolerance` parameter, to tune the face recognition sensitivity and display the distance next to the recognized name. 

Hope you will like it!