### PR TITLE
Additional classes to give more control

### DIFF
--- a/MMM-Face-Reco-DNN.js
+++ b/MMM-Face-Reco-DNN.js
@@ -14,10 +14,18 @@ Module.register('MMM-Face-Reco-DNN', {
     logoutDelay: 15000,
     // How many time the recognition starts, with a RasPi 3+ it would be good every 2 seconds
     checkInterval: 2000,
+    // Module set used for when there is no face detected ie no one is in front of the camera
+    noFaceClass: 'noface',
+    // Module set used for when there is an unknown/unrecognised face detected 
+    unknownClass: 'unknown',
+    // Module set used for when there is a known/recognised face detected 
+    knownClass: 'known',
     // Module set used for strangers and if no user is detected
     defaultClass: 'default',
-    // Set of modules which should be shown for every user
+    // Set of modules which should be shown for any user ie when there is any face detected
     everyoneClass: 'everyone',
+    // Set of modules that are always shown - show if there is a face or no face detected
+    alwaysClass: 'always',
     // xml to recognize with haarcascae
     cascade:
       'modules/MMM-Face-Reco-DNN/tools/haarcascade_frontalface_default.xml',
@@ -46,17 +54,33 @@ Module.register('MMM-Face-Reco-DNN', {
     // if extenDataset is set, you need to set the full path of the dataset
     dataset: 'modules/MMM-Face-Reco-DNN/dataset/',
     // How much distance between faces to consider it a match. Lower is more strict.
-    tolerance: 0.6
+    tolerance: 0.6,
+    // allow multiple concurrent user logins, 0=no, 1=yes
+    multiUser: 0,
+    // turn on extra debugging 0=no, 1=yes
+    debug: 0,
+    
   },
 
   timouts: {},
   users: [],
 
+  // ----------------------------------------------------------------------------------------------------
   start: function() {
     this.sendSocketNotification('CONFIG', this.config);
     Log.log('Starting module: ' + this.name);
+
+    this.config.debug && Log.log(this.config);
+
+    // there are 3 states (noface, unknown face, known face). Each of these has classes that allow them
+    // this configuration defines which classes provide which states
+    this.config.classes_noface =[this.config.noFaceClass, this.config.defaultClass,                           this.config.alwaysClass];
+    this.config.classes_unknown=[this.config.unknownClass,this.config.defaultClass, this.config.everyoneClass,this.config.alwaysClass];
+    this.config.classes_known  =[this.config.knownClass,                            this.config.everyoneClass,this.config.alwaysClass];
+
   },
 
+  // ----------------------------------------------------------------------------------------------------
   // Define required translations.
   getTranslations: function() {
     return {
@@ -74,88 +98,217 @@ Module.register('MMM-Face-Reco-DNN', {
     };
   },
 
+  // ----------------------------------------------------------------------------------------------------
   login_user: function(name) {
     var self = this;
+    
+    Log.log('Logged in user:' + name);
+    this.config.debug && Log.log('User list:' + this.users);
 
-    MM.getModules()
-      .withClass(this.config.defaultClass)
-      .exceptWithClass(this.config.everyoneClass)
-      .enumerate(function(module) {
-        module.hide(
-          self.config.animationSpeed,
-          function() {
-            Log.log(module.name + ' is hidden.');
-          },
-          {
-            lockString: self.identifier,
-          }
-        );
-      });
+    // what we do here depends on if we recognise the user or not
+    if (name === 'unknown') {
+      // this is the state of an unknown face
+      // we want to show the new classes allowed by this target state (unknown state)
+      this.show_modules(this.config.classes_unknown,this.config.classes_noface);
+      
+      // we want to hide the old classes from the previous state (noface state)
+      this.hide_modules(this.config.classes_noface,this.config.classes_unknown);
 
-    MM.getModules()
-      .withClass(name.toLowerCase())
-      .enumerate(function(module) {
-        module.show(
-          self.config.animationSpeed,
-          function() {
-            Log.log(module.name + ' is shown.');
-          },
-          {
-            lockString: self.identifier,
-          }
-        );
-      });
-
+    } else {
+     // this is the state of a known face
+     // we want to show the new classes allowed by this target state (known state)
+     // copy the config classes to a new array
+     var newClasses=this.config.classes_known.slice();
+     this.config.debug && Log.log('Adding ' + name + ' to ' + this.config.classes_known);
+     newClasses.push(name.toLowerCase());
+     
+     // we want to show the new classes allowed by this target state (known state)
+     this.show_modules(newClasses,this.config.classes_noface);
+      
+      // we want to hide the old classes from the previous state (noface state)
+      this.hide_modules(this.config.classes_noface,newClasses);
+    }
+    
+    // now show a welcome message
     if (this.config.welcomeMessage) {
       var person = name;
+      var welcomeMessage;
+  
       // We get unknown from Face-Reco and then it should be translated to stranger
       if (person === 'unknown') {
         person = this.translate('stranger');
+        welcomeMessage = this.translate('unknownlogin').replace('%person', person);
+      } else {
+        // set up the slightly different message for a known person
+        welcomeMessage = this.translate('knownlogin').replace('%person', person);
       }
 
       this.sendNotification('SHOW_ALERT', {
         type: 'notification',
-        message: this.translate('message').replace('%person', person),
+        message: welcomeMessage,
         title: this.translate('title'),
       });
     }
+
+    
   },
 
+  // ----------------------------------------------------------------------------------------------------
   logout_user: function(name) {
     var self = this;
 
-    MM.getModules()
-      .withClass(name.toLowerCase())
-      .enumerate(function(module) {
-        module.hide(
-          self.config.animationSpeed,
-          function() {
-            Log.log(module.name + ' is hidden.');
-          },
-          {
-            lockString: self.identifier,
-          }
-        );
-      });
+    Log.log('Logged out user:' + name);
+    this.config.debug && Log.log('User list:' + this.users);
 
+    // see how many users are left
     if (this.users.length === 0) {
-      MM.getModules()
-        .withClass(self.config.defaultClass)
-        .exceptWithClass(self.config.everyoneClass)
-        .enumerate(function(module) {
-          module.show(
-            self.config.animationSpeed,
-            function() {
-              Log.log(module.name + ' is shown.');
-            },
-            {
-              lockString: self.identifier,
-            }
-          );
-        });
+      // no users left, so we are going to the noface state
+      // the name of the logging out user determines what state we are coming from
+      
+      // what we do here depends on if we recognise the user or not
+      if (name === 'unknown') {
+       // this is the transition from the unknown state to the noface state
+
+       // we want to show the new classes allowed by this target state (noface state)
+       this.show_modules(this.config.classes_noface,this.config.classes_unknown);
+
+       // we want to hide the old classes from the previous state (unknown state)
+       this.hide_modules(this.config.classes_unknown,this.config.classes_noface);
+       
+      } else {
+       // this is the transition from the known state to the noface state
+
+       // we want to show the new classes allowed by this target state (noface state)
+       // copy the config classes to a new array
+       var oldClasses=this.config.classes_known.slice();
+       this.config.debug && Log.log('Adding ' + name + ' to ' + this.config.classes_known);
+       oldClasses.push(name.toLowerCase());
+       
+       // we want to show the new classes allowed by this target state (noface state)
+       this.show_modules(this.config.classes_noface,oldClasses);
+        
+       // we want to hide the old classes from the previous state (known state)
+       this.hide_modules(oldClasses,this.config.classes_noface);
+      }
+    } else {
+      // in this transition we go from multiple users to a lower number of users, leaving one or more logged in
+      // the logic for this is not fully developed
+      // to do this properly you have to go through all the remaining users and work out what classes would be left after we remove this one user
+      // start by removing only the classes related to this user
+      // this might not always be right as you might leave behind an unknown user etc
+      // what we do here depends on if we recognise the user or not
+      if (name === 'unknown') {
+       // we want to hide the old classes related to an unknown users
+       this.config.debug && Log.log('Hiding all old classes:' + this.config.classes_unknown);
+       
+      } else {
+       var oldClasses=this.config.classes_known;
+       oldClasses.push(name.toLowerCase());
+       
+       // we want to hide the old classes related to a known user
+       this.hide_modules(oldClasses,0);
+      }
     }
+    
   },
 
+  // ----------------------------------------------------------------------------------------------------
+  show_modules: function(showClasses,exceptClasses) {
+    // show modules with "showClasses" except for those with "exceptClasses"
+    var self = this;
+    this.config.debug && Log.log('Showing all new classes:' + showClasses + ', except old classes:' + exceptClasses);
+    MM.getModules()
+      .withClass(showClasses)
+      .exceptWithClass(exceptClasses)
+      .enumerate(function(module) {
+       module.show(
+         self.config.animationSpeed,
+         function() {
+           Log.log(module.name + ' is shown.');
+         },
+         {
+           lockString: self.identifier,
+         }
+       );
+      });
+  },
+  // ----------------------------------------------------------------------------------------------------
+  hide_modules_new: function(hideClasses,exceptClasses) {
+    // hide modules with "hideClasses" except for those with "exceptClasses"
+    var self = this;
+    this.config.debug && Log.log('Hiding all old classes:' + hideClasses + ', except new classes:' + exceptClasses);
+    var modules=MM.getModules();
+    modules = hideClasses && modules.withClass(hideClasses);
+    modules = exceptClasses && modules.exceptWithClass(exceptClasses);
+    modules.enumerate(function(module) {
+       module.hide(
+         self.config.animationSpeed,
+         function() {
+           Log.log(module.name + ' is hidden.');
+         },
+         {
+           lockString: self.identifier,
+         }
+       );
+     });
+  },
+  // ----------------------------------------------------------------------------------------------------
+  hide_modules: function(hideClasses,exceptClasses) {
+    // hide modules with "hideClasses" except for those with "exceptClasses"
+    var self = this;
+    // there must be a fancier javascript way to do this if with just runs that same getModules code but with different collections of selectors
+    // look to fix this later
+    if (hideClasses===0) {
+      this.config.debug && Log.log('Hiding all classes except new classes:' + exceptClasses);
+      MM.getModules()
+       .exceptWithClass(exceptClasses)
+       .enumerate(function(module) {
+         module.hide(
+           self.config.animationSpeed,
+           function() {
+             Log.log(module.name + ' is hidden.');
+           },
+           {
+             lockString: self.identifier,
+           }
+         );
+       });
+    } else if (exceptClasses===0) {
+      this.config.debug && Log.log('Hiding old classes:' + hideClasses);
+      MM.getModules()
+       .withClass(hideClasses)
+       .enumerate(function(module) {
+         module.hide(
+           self.config.animationSpeed,
+           function() {
+             Log.log(module.name + ' is hidden.');
+           },
+           {
+             lockString: self.identifier,
+           }
+         );
+       });
+    } else {
+      this.config.debug && Log.log('Hiding all old classes:' + hideClasses + ', except new classes:' + exceptClasses);
+      MM.getModules()
+       .withClass(hideClasses)
+       .exceptWithClass(exceptClasses)
+       .enumerate(function(module) {
+         module.hide(
+           self.config.animationSpeed,
+           function() {
+             Log.log(module.name + ' is hidden.');
+           },
+           {
+             lockString: self.identifier,
+           }
+         );
+       });
+    }
+    
+    
+  },
+  // ----------------------------------------------------------------------------------------------------
   socketNotificationReceived: function(notification, payload) {
     var self = this;
     var user;
@@ -164,9 +317,23 @@ Module.register('MMM-Face-Reco-DNN', {
     if (payload.action === 'login') {
       for (user of payload.users) {
         if (user != null) {
-          this.users.push(user);
-          this.login_user(user);
+         
+          // if there are currently no users logged in OR we allow multiple users
+          if (this.users.length === 0 || this.config.multiUser) {
+            // check if the user is already logged in
+            if (!this.users.includes(user)) {
+              // user not currently logged in so add them to the list of logged in users
+              this.users.push(user);
+              // run the login procedure
+              this.login_user(user);
+            } else {
+              this.config.debug && Log.log('Detected ' + user + ' again.');
+            }
+          } else {
+            this.config.debug && Log.log('Detected a login event for ' + user + ' but multiple concurrent logins is disabled and ' + this.users + ' is already logged in.');
+          }
 
+          // clear the any timeouts the user might have so that they stay logged in
           if (this.timouts[user] != null) {
             clearTimeout(this.timouts[user]);
           }
@@ -176,12 +343,17 @@ Module.register('MMM-Face-Reco-DNN', {
     } else if (payload.action === 'logout') {
       for (user of payload.users) {
         if (user != null) {
-          this.timouts[user] = setTimeout(function() {
-            self.users = self.users.filter(function(u) {
-              return u !== user;
-            });
-            self.logout_user(user);
-          }, this.config.logoutDelay);
+          // see if user is even logged in, since you can only log out if you are actually logged in
+          if (this.users.includes(user)) {
+            this.timouts[user] = setTimeout(function() {
+              self.users = self.users.filter(function(u) {
+                return u !== user;
+              });
+              self.logout_user(user);
+            }, this.config.logoutDelay);
+          } else {
+            this.config.debug && Log.log('Detected a logout event for ' + user + ' but they were not logged in.');
+          }
         }
       }
 
@@ -189,25 +361,17 @@ Module.register('MMM-Face-Reco-DNN', {
     }
   },
 
+  // ----------------------------------------------------------------------------------------------------
   notificationReceived: function(notification, payload, sender) {
     var self = this;
 
     // Event if DOM is created
     if (notification === 'DOM_OBJECTS_CREATED') {
-      // Show all Modules with default class
-      MM.getModules()
-        .exceptWithClass(this.config.defaultClass)
-        .enumerate(function(module) {
-          module.hide(
-            0,
-            function() {
-              Log.log('Module is hidden.');
-            },
-            {
-              lockString: self.identifier,
-            }
-          );
-        });
+      // at startup modules will already be shown
+      // we want to hide modules (by class) that are not supposed to be shown
+      // in this case we want to hide any class except those which bring us to the noface state
+      // this list of classes is contained in this.classes_noface
+      this.hide_modules(0,this.config.classes_noface);
     }
 
     // load logged in users

--- a/MMM-Face-Reco-DNN.js
+++ b/MMM-Face-Reco-DNN.js
@@ -233,26 +233,6 @@ Module.register('MMM-Face-Reco-DNN', {
       });
   },
   // ----------------------------------------------------------------------------------------------------
-  hide_modules_new: function(hideClasses,exceptClasses) {
-    // hide modules with "hideClasses" except for those with "exceptClasses"
-    var self = this;
-    this.config.debug && Log.log('Hiding all old classes:' + hideClasses + ', except new classes:' + exceptClasses);
-    var modules=MM.getModules();
-    modules = hideClasses && modules.withClass(hideClasses);
-    modules = exceptClasses && modules.exceptWithClass(exceptClasses);
-    modules.enumerate(function(module) {
-       module.hide(
-         self.config.animationSpeed,
-         function() {
-           Log.log(module.name + ' is hidden.');
-         },
-         {
-           lockString: self.identifier,
-         }
-       );
-     });
-  },
-  // ----------------------------------------------------------------------------------------------------
   hide_modules: function(hideClasses,exceptClasses) {
     // hide modules with "hideClasses" except for those with "exceptClasses"
     var self = this;

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ To setup the module in MagicMirror², add the following section to the `config.j
       // If extendDataset is true, you need to set the full path of the dataset
       dataset: 'modules/MMM-Face-Reco-DNN/dataset/',
       // How much distance between faces to consider it a match. Lower is more strict.
-      tolerance: 0.6
+      tolerance: 0.6,
       // allow multiple concurrent user logins, 0=no, 1=yes
       multiUser: 0,
     }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ sudo apt-get -f install
 sudo dpkg -i opencv_4.1.2-1_armhf.deb
 ```
 
+### <a name="pip"></a>pip
+
+If you have both python v2 and python v3 installed then you may need to be specific in the use of either pip or pip3. If you are targetting python v3 then you will need to substitute pip3 instead of pip in the example commmands below.
+If you have only a single version of python installed then you may use pip.
+
 ### <a name="dlib"></a>dlib
 
 You can install dlib easily using pip with the following command.
@@ -179,10 +184,18 @@ To setup the module in MagicMirror², add the following section to the `config.j
       // How often the recognition starts in milliseconds
       // With a Raspberry Pi 3+ it works well every 2 seconds
       checkInterval: 2000,
-      // Module set used for strangers or if no user is detected
+      // Module set used for when there is no face detected ie no one is in front of the camera
+      noFaceClass: 'noface',
+      // Module set used for when there is an unknown/unrecognised face detected 
+      unknownClass: 'unknown',
+      // Module set used for when there is a known/recognised face detected 
+      knownClass: 'known',
+      // Module set used for strangers and if no user is detected
       defaultClass: 'default',
-      // Set of modules which should be shown for every recognised user
+      // Set of modules which should be shown for any user ie when there is any face detected
       everyoneClass: 'everyone',
+      // Set of modules that are always shown - show if there is a face or no face detected
+      alwaysClass: 'always',
       // XML to recognize with haarcascade
       cascade: 'modules/MMM-Face-Reco-DNN/tools/haarcascade_frontalface_default.xml',
       // Pre-encoded pickle with the faces
@@ -216,39 +229,12 @@ To setup the module in MagicMirror², add the following section to the `config.j
       dataset: 'modules/MMM-Face-Reco-DNN/dataset/',
       // How much distance between faces to consider it a match. Lower is more strict.
       tolerance: 0.6
+      // allow multiple concurrent user logins, 0=no, 1=yes
+      multiUser: 0,
     }
 }
 ```
 
-In order for this module to do anything useful you have to assign classes to your modules.
-
-- The class `default` (if you don't rename it) is shown if no user or a stranger is detected
-- The class `everyone` (again if you don't change it) is shown for all users
-- To specify modules for a certain user, use their name as the class name
-
-Do *not* set any classes on this module, it has no output and will not work.
-
-```js
-{
-    module: 'example_module',
-    position: 'top_left',
-    // Set your classes here seperated by a space
-    // Shown for all users
-    classes: 'default everyone'
-},
-{
-    module: 'example_module_2',
-    position: 'top_left',
-    // Only shown for Thierry and James
-    classes: 'thierry james'
-},
-{
-    module: 'example_module_3',
-    position: 'top_right',
-    // Only shown for James
-    classes: 'james'
-}
-```
 
 ## Notifications
 
@@ -267,7 +253,11 @@ The module sends notifications if a user is logged in or logged out. In addition
 |---|---|
 | `logoutDelay` | Log out this long after user was not detected any more. If they are detected within this period, the delay will start again. <br />**Default Value:** `15000` |
 | `checkInterval` | How often the recognition starts in milliseconds. With a Raspberry Pi 3+ it works well every 2 seconds. <br />**Default Value:** `2000` |
+| `noFaceClass`  | Module set used for when there is no face detected ie no one is in front of the camera. <br />**Default Value:** `noface` |
+| `unknownClass`  | Module set used for when there is an unknown/unrecognised face detected. <br />**Default Value:** `unknown` |
+| `knownClass`  |  Module set used for when there is a known/recognised face detected <br />**Default Value:** `known`|
 | `defaultClass` | Module set used for strangers or if no user is detected. <br />**Default Value:** `default` |
+| `alwaysClass`  |  Set of modules that are always shown - show if there is a face or no face detected. <br />**Default Value:** `always` |
 | `everyoneClass` | Set of modules which should be shown for every recognised user. <br />**Default Value:** `everyone` |
 | `cascade` | XML to recognize with haarcascade. <br />**Default Value:** `modules/MMM-Face-Reco-DNN/tools/haarcascade_frontalface_default.xml`. |
 | `encodings` | Pre-encoded pickle with the faces. <br />**Default Value:** `modules/MMM-Face-Reco-DNN/tools/encodings.pickle` |
@@ -279,8 +269,127 @@ The module sends notifications if a user is logged in or logged out. In addition
 | `welcomeMessage` | Should a welcome message be shown using the MagicMirror alerts module? <br />**Default Value:** `true` |
 | `extendDataset` | Capture new pictures of recognized people, if unknown we save it in folder "unknown". So you can extend your dataset and retrain it afterwards for better recognitions. <br />**Default Value:** `false` |
 | `dataset` | If `extendDataset` is true, you need to set the full path of the dataset as well. <br /> **Default Value:** `modules/MMM-Face-Reco-DNN/dataset/` |
+| `multiUser` | Allow multiple concurrent user logins, 0=no, 1=yes <br /> **Default Value:** `0` |
+
+## Facial Recognition States
+
+There are 3 states that of facial recogntion that this module runs in. The states are not directly configurable but rather you use the classes to define which modules are activated in the various states. 
+
+| State | Description |
+|---|---|
+| noface | This is the state when facial recognition has found no faces |
+| unknown | This is the state when facial recognition has found a face that it does NOT recognise |
+| known  | This is the state when facial recognition has found a face that it does recognise |
+
+## Classes
+
+In order for this module to do anything useful you have to assign classes to your modules. Do *not* set any classes on this module itself, it has no output and will not work.
+
+There are a series of classes that drive the showing/hiding of modules based on the state of facial recognition. The following table gives a view of which classes drive which states.
+
+When a state changes, the classes from the old state are hidden and the classes from the new state are shown. Anytime that a specific class appears in both states, nothing happens to the modules tagged with that specific class.
+
+For example:
+- starting from no faces detected, when an unknown face is detected, any modules tagged with the `noface` class will disappear and any modules tagged with the `unknown` class will appear.
+- starting from no faces detected, when an unknown face is detected, any modules tagged with the `default` class will remain unchanged, because `default` provides both the Noface and the Unknown states.
+- starting from no faces detected, when an known face is detected, any modules tagged with the `default` class will be hidden and modules tagged with `known` or "specific user's name" ie to specify modules for a certain user, use their name as the class name
+
+
+The state to class mappings are:
+<table>
+  <thead>
+    <tr>
+      <td></td>
+      <td colspan=3>States that the class is active in</td>
+    </tr>
+    <tr>
+      <td><b>Class</b></td>
+      <td><b>Noface</b></td>
+      <td><b>Unknown</b></td>
+      <td><b>Known</b></td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>noface</code></td>
+      <td align=center>Y</td>
+      <td align=center></td>
+      <td align=center></td>
+    </tr>
+    <tr>
+      <td><code>unknown</code></td>
+      <td align=center></td>
+      <td align=center>Y</td>
+      <td align=center></td>
+    </tr>
+    <tr>
+      <td><code>known</code></td>
+      <td align=center></td>
+      <td align=center></td>
+      <td align=center>Y</td>
+    </tr>
+    <tr>
+      <td><code>default</code></td>
+      <td align=center>Y</td>
+      <td align=center>Y</td>
+      <td align=center></td>
+    </tr>
+    <tr>
+      <td><code>everyone</code></td>
+      <td align=center></td>
+      <td align=center>Y</td>
+      <td align=center>Y</td>
+    </tr>
+    <tr>
+      <td><code>always</code></td>
+      <td align=center>Y</td>
+      <td align=center>Y</td>
+      <td align=center>Y</td>
+    </tr>
+    <tr>
+      <td><code>"specific user's name"</code></td>
+      <td align=center></td>
+      <td align=center></td>
+      <td align=center>Y</td>
+    </tr>
+  </tbody>
+</table>
+
+```js
+{
+    module: 'example_module',
+    position: 'top_left',
+    // Set your classes here seperated by a space
+    // Always shown
+    classes: 'always'
+},
+{
+    module: 'example_module_2',
+    position: 'top_left',
+    // Only shown for Thierry and James
+    classes: 'thierry james'
+},
+{
+    module: 'example_module_3',
+    position: 'top_right',
+    // Only shown for James
+    classes: 'james'
+}
+{
+    module: 'example_module_4',
+    position: 'top_right',
+    // Only shown for known (recognised users)
+    classes: 'known'
+}
+```
+
+## Known Issues
+
+- Support for multiple concurrently logged in users is not yet complete.
 
 ## Credits
 
 - Adrian Rosebrock for the great tutorial: https://www.pyimagesearch.com/2018/06/25/raspberry-pi-face-recognition/
 - Normyx for the first version of Face-Recognition for MagicMirror: https://github.com/normyx/MMM-Facial-Recognition-OCV3
+
+

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -1,5 +1,6 @@
 {
-  "message": "Здравей %person, радвам се да те видя!",
+  "knownlogin": "Здравей %person!",
+  "unknownlogin": "Здравей %person, радвам се да те видя!",
   "title": "Лицево разпознаване",
   "stranger": "непознат"
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,5 +1,6 @@
 {
-  "message": "Hallo %person, schön dich zu sehen!",
+  "knownlogin": "Hallo %person!",
+  "unknownlogin": "Hallo %person, schön dich zu sehen!",
   "title": "Gesichtserkennung",
   "stranger": "Fremder"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,5 +1,6 @@
 {
-  "message": "Hello %person, nice to meet you!",
+  "knownlogin": "Hello %person!",
+  "unknownlogin": "Hello %person, nice to meet you!",
   "title": "Facial-Recognition",
   "stranger": "stranger"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,5 +1,6 @@
 {
-  "message": "Hola %person, ¡que bueno verte de nuevo!",
+  "knownlogin": "Hola %person!",
+  "unknownlogin": "Hola %person, ¡que bueno verte de nuevo!",
   "title": "Facial-Recognition",
   "stranger": "desconocido"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1,5 +1,6 @@
 {
-  "message": "Bonjour %person, ravi de vous rencontrer !",
+  "knownlogin": "Bonjour %person!",
+  "unknownlogin": "Bonjour %person, ravi de vous rencontrer !",
   "title": "Reconnaissance Faciale",
   "stranger": "Etranger"
 }

--- a/translations/id.json
+++ b/translations/id.json
@@ -1,5 +1,6 @@
 {
-  "message": "Halo %person, senang bertemu Anda!",
+  "knownlogin": "Halo %person!",
+  "unknownlogin": "Halo %person, senang bertemu Anda!",
   "title": "Pengenalan Wajah",
   "stranger": "orang asing"
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -1,5 +1,6 @@
 {
-  "message": "Ciao %person,piacere di rivederti!",
+  "knownlogin": "Ciao %person!",
+  "unknownlogin": "Ciao %person,piacere di rivederti!",
   "title": "Facial-Recognition",
   "stranger": "sconosciuto"
 }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -1,5 +1,6 @@
 {
-  "message": "Hallo %person, goed je te zien!",
+  "knowlogin": "Hallo %person!",
+  "unknownlogin": "Hallo %person, goed je te zien!",
   "title": "Gezichtsherkenning",
   "stranger": "vreemde"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -1,5 +1,6 @@
 {
-  "message": "Привет, %person, приятно тебя видеть!",
+  "knownlogin": "Привет, %person!",
+  "unknownlogin": "Привет, %person, приятно тебя видеть!",
   "title": "Распознавание лиц",
   "stranger": "незнакомец"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -1,5 +1,6 @@
 {
-  "message": "Hej %person, trevligt att träffas!",
+  "knownlogin": "Hej %person!",
+  "unknownlogin": "Hej %person, trevligt att träffas!",
   "title": "Ansiktsigenkänning",
   "stranger": "Besökare"
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -1,5 +1,6 @@
 {
-  "message": "你好 %person, 很高興看到你!",
+  "knownlogin": "你好 %person!",
+  "unknownlogin": "你好 %person, 很高興看到你!",
   "title": "臉部識別",
   "stranger": "陌生人"
 }


### PR DESCRIPTION
I've added more classes to give more control over which modules can be shown and when. The motivation for this was that I wanted to use the facial recognition module in combination with a carousel module. This needed some additional classes so that I could make the facial recognition module not touch the carousel controlled modules. When facial recognition and carousel tried to show/hide the same modules, it looked a bit ugly (all carousel modules were shown at the same time) until the second cycle of the carousel came around. The new 'always' class means that at least now you can have a class that is always shown ie not touched by facial recognition.

I also found that having multiple concurrent logged in users could make a mess of the modules shown/hidden. For now I have made a configuration setting that defaults to limiting to a single logged in user at a time. There is more work for me to do in this area to properly support multiple concurrent logins. 

I've also updated the documentation with all these changes

I have changed the welcome message to support a different message when the user is known vs unknown and modified all translations to also support this.