### PR TITLE
add user mapping for welcome message purposes

### DIFF
--- a/MMM-Face-Reco-DNN.js
+++ b/MMM-Face-Reco-DNN.js
@@ -48,6 +48,10 @@ Module.register('MMM-Face-Reco-DNN', {
     pythonPath: null,
     // Boolean to toggle welcomeMessage
     welcomeMessage: true,
+    // Dictionary for person name mapping in welcome message
+    // Allows for displaying name with complex character sets in welcome message 
+    // e.g. jerome => Jérôme, hideyuki => 英之, mourad => مراد 
+    usernameDisplayMapping: null,
     // Save some pictures from recognized people, if unknown we save it in folder "unknown"
     // So you can extend your dataset and retrain it afterwards for better recognitions
     extendDataset: false,
@@ -165,8 +169,12 @@ Module.register('MMM-Face-Reco-DNN', {
         person = this.translate('stranger');
         welcomeMessage = this.translate('unknownlogin').replace('%person', person);
       } else {
-        // set up the slightly different message for a known person
-        welcomeMessage = this.translate('knownlogin').replace('%person', person);
+        // set up the slightly different message for a known person, attempt to find a Name mapping for display purposes
+        var personDisplayName = person;
+        if (this.config.usernameDisplayMapping && this.config.usernameDisplayMapping[person]) {
+          personDisplayName = this.config.usernameDisplayMapping[person];
+        } 
+        welcomeMessage = this.translate('knownlogin').replace('%person', personDisplayName);
       }
 
       this.sendNotification('SHOW_ALERT', {

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ To setup the module in MagicMirror², add the following section to the `config.j
       pythonPath: null,
       // Should a welcome message be shown using the MagicMirror alerts module?
       welcomeMessage: true,
+      // Dictionary for person name mapping in welcome message
+      // Allows for displaying name with complex character sets in welcome message e.g. jerome => Jérôme, hideyuki => 英之
+      usernameDisplayMapping: null,
       // Capture new pictures of recognized people, if unknown we save it in folder "unknown"
       // So you can extend your dataset and retrain it afterwards for better recognitions
       extendDataset: false,
@@ -276,6 +279,7 @@ The module sends notifications if a user is logged in or logged out. In addition
 | `animationSpeed`  | How long in milliseconds modules take to hide and show. <br />**Default Value:** `0`                                                                                                                     |
 | `pythonPath`      | Path to Python to run the face recognition. <br />**Default Value:** `null`                                                                                                                              |
 | `welcomeMessage`  | Should a welcome message be shown using the MagicMirror alerts module? <br />**Default Value:** `true`                                                                                                   |
+| `usernameDisplayMapping`  | Dictionary for mapping usernames (dataset directory names) to more complex character sets in the welcome message<br /> Example:` {"jerome" : "Jérôme", "hideyuki" : "英之", "mourad" : "مراد" }`  <br />**Default Value:** `null` (usernames remain as defined in the dataset directory structure)                                                                                                  |
 | `extendDataset`   | Capture new pictures of recognized people, if unknown we save it in folder "unknown". So you can extend your dataset and retrain it afterwards for better recognitions. <br />**Default Value:** `false` |
 | `dataset`         | If `extendDataset` is true, you need to set the full path of the dataset as well. <br /> **Default Value:** `modules/MMM-Face-Reco-DNN/dataset/`                                                         |
 | `multiUser`       | Allow multiple concurrent user logins, 0=no, 1=yes <br /> **Default Value:** `0`                                                                                                                         |


### PR DESCRIPTION
Implemented a simple addition in order to be able to map usernames (taken from the directory structure) to more complex character sets for the welcome message:
eg. jerome => Jérôme, hideyuki => 英之, mourad => مراد