### PR TITLE
Fix for empty sequence #84

### DIFF
--- a/tools/facerecognition.py
+++ b/tools/facerecognition.py
@@ -137,15 +137,16 @@ while True:
 	# compute the facial embeddings for each face bounding box
 	encodings = face_recognition.face_encodings(rgb, boxes)
 	names = []
-	minDistance = 0.0
 
 	# loop over the facial embeddings
 	for encoding in encodings:
 		# compute distances between this encoding and the faces in dataset
 		distances = face_recognition.face_distance(data["encodings"], encoding)
 
-		# the smallest distance is the closest to the encoding
-		minDistance = min(distances)
+		minDistance = 1.0
+		if len(distances) > 0:
+			# the smallest distance is the closest to the encoding
+			minDistance = min(distances)
 
 		# save the name if the distance is below the tolerance
 		if minDistance < tolerance:


### PR DESCRIPTION
When the pickle is valid, but has no known images, then there
will be an empty set of target users, and when checking the
distance to users, it will break with an empty sequence
error as found in #84. This patch is a simple fix that defaults
the loop to the unknown user - no users mean it will consider
it a detected face, but unknown.